### PR TITLE
Issue02 players precedence info

### DIFF
--- a/Arena/src/Game.TankBlaster/Models/BotBattlefieldInfo.cs
+++ b/Arena/src/Game.TankBlaster/Models/BotBattlefieldInfo.cs
@@ -8,6 +8,7 @@ namespace Game.TankBlaster.Models
     public class BotBattlefieldInfo
     {
         public int RoundNumber { get; set; }
+        public int TurnNumber { get; set; }
         public Guid BotId { get; set; }
         public BoardTile[,] Board { get; set; }
         public Point BotLocation { get; set; }

--- a/Arena/src/Game.TankBlaster/Services/BotService.cs
+++ b/Arena/src/Game.TankBlaster/Services/BotService.cs
@@ -44,12 +44,14 @@ namespace Game.TankBlaster.Services
                 History = new List<RoundPartialHistory>()
             };
 
+            int turnNumber = 0;
             foreach (var dynaBlasterBot in _field.Bots.Where(bot => !bot.IsDead))
             {
                 BotMove move;
                 try
                 {
-                    move = await dynaBlasterBot.NextMoveAsync(GetBotBattlefieldInfo(dynaBlasterBot, roundNumber));
+                    turnNumber++;
+                    move = await dynaBlasterBot.NextMoveAsync(GetBotBattlefieldInfo(dynaBlasterBot, roundNumber, turnNumber));
                 }
                 catch (Exception e)
                 {
@@ -107,11 +109,12 @@ namespace Game.TankBlaster.Services
             return _gameConfig.MissileBlastRadius + (_gameConfig.RoundsBeforeIncreasingBlastRadius == 0 ? 0 : (roundNumber/_gameConfig.RoundsBeforeIncreasingBlastRadius));
         }
 
-        private BotBattlefieldInfo GetBotBattlefieldInfo(TankBlasterBot bot, int roundNumber)
+        private BotBattlefieldInfo GetBotBattlefieldInfo(TankBlasterBot bot, int roundNumber, int turnNumber)
         {
             return new BotBattlefieldInfo
             {
                 RoundNumber = roundNumber,
+                TurnNumber = turnNumber,
                 BotId = bot.Id,
                 Board = _field.Board,
                 Bombs = _field.Bombs.Cast<IBomb>().ToList(),

--- a/JAVA/TankBlasterBot/src/bot/BotArenaInfo.java
+++ b/JAVA/TankBlasterBot/src/bot/BotArenaInfo.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.SerializedName;
 
 public class BotArenaInfo {
 	public int RoundNumber;
+	public int TurnNumber;
 	public UUID BotId;
 	public int[][] Board;
 	private String BotLocation;

--- a/PHP/TankBlaster/TankBlasterBot/PerformNextMove.php
+++ b/PHP/TankBlaster/TankBlasterBot/PerformNextMove.php
@@ -13,6 +13,8 @@ class BotArenaInfo
 
 	{
 	public $RoundNumber;
+	
+	public $TurnNumber;
 
 	public $BotId;
 

--- a/dotNet/TankBlaster/TankBlasterBot/SampleWebBotClient/Models/TankBlaster/BotArenaInfo.cs
+++ b/dotNet/TankBlaster/TankBlasterBot/SampleWebBotClient/Models/TankBlaster/BotArenaInfo.cs
@@ -7,6 +7,7 @@ namespace SampleWebBotClient.Models.TankBlaster
     public class BotArenaInfo
     {
         public int RoundNumber { get; set; }
+        public int TurnNumber { get; set; }
         public Guid BotId { get; set; }
         public BoardTile[,] Board { get; set; }
         public Point BotLocation { get; set; }


### PR DESCRIPTION
Extending BotArenaInfo with TurnNumber field. The turn number is equal to one, if the player move first in each round and is equal to two in other case. Therefore more sophisticated bot strategy can be implemented, including partial players move tree evaluation. It's small change in api, allowing variety of new strategies for bot makers.