### PR TITLE
Issue01 missing rounds until explodes

### DIFF
--- a/Arena/bin/TankBlaster.config.xml
+++ b/Arena/bin/TankBlaster.config.xml
@@ -3,9 +3,10 @@
   <MapWidth>20</MapWidth>
   <MapHeight>20</MapHeight>
   <BombBlastRadius>2</BombBlastRadius>
+  <BombRoundsUntilExplodes>5</BombRoundsUntilExplodes>
   <MissileBlastRadius>2</MissileBlastRadius>
   <RoundsBetweenMissiles>5</RoundsBetweenMissiles>
-  
+    
   <!-- Increase explosion range every x rounds to increase difficulty -->
   <RoundsBeforeIncreasingBlastRadius>70</RoundsBeforeIncreasingBlastRadius> <!-- set to 0 to disable this feature-->
   <!-- If set to "true", missile will explode in the same round that it reaches its last free location. Otherwise it will explode in the next round -->

--- a/Arena/src/Game.TankBlaster/Models/TankBlasterConfig.cs
+++ b/Arena/src/Game.TankBlaster/Models/TankBlasterConfig.cs
@@ -12,5 +12,6 @@ namespace Game.TankBlaster.Models
         public int RoundsBetweenMissiles { get; set; }
         public int RoundsBeforeIncreasingBlastRadius { get; set; }
         public bool IsFastMissileModeEnabled { get; set; }
+        public int BombRoundsUntilExplodes { get; set; }
     }
 }

--- a/Arena/src/Game.TankBlaster/Services/BotService.cs
+++ b/Arena/src/Game.TankBlaster/Services/BotService.cs
@@ -147,7 +147,7 @@ namespace Game.TankBlaster.Services
                 _field.Bombs.Add(new Bomb
                 {
                     Location = bot.Location,
-                    RoundsUntilExplodes = 5,
+                    RoundsUntilExplodes = _gameConfig.BombRoundsUntilExplodes,
                     ExplosionRadius = CurrentBombBlastRadius(roundNumber)
                 });
 

--- a/Arena/src/Game.TankBlaster/TankBlaster.config.xml
+++ b/Arena/src/Game.TankBlaster/TankBlaster.config.xml
@@ -3,9 +3,10 @@
   <MapWidth>20</MapWidth>
   <MapHeight>20</MapHeight>
   <BombBlastRadius>2</BombBlastRadius>
+  <BombRoundsUntilExplodes>5</BombRoundsUntilExplodes>
   <MissileBlastRadius>2</MissileBlastRadius>
   <RoundsBetweenMissiles>5</RoundsBetweenMissiles>
-  
+    
   <!-- Increase explosion range every x rounds to increase difficulty -->
   <RoundsBeforeIncreasingBlastRadius>70</RoundsBeforeIncreasingBlastRadius> <!-- set to 0 to disable this feature-->
   <!-- If set to "true", missile will explode in the same round that it reaches its last free location. Otherwise it will explode in the next round -->

--- a/JAVA/TankBlasterBot/src/bot/TankBlasterConfig.java
+++ b/JAVA/TankBlasterBot/src/bot/TankBlasterConfig.java
@@ -7,4 +7,5 @@ public class TankBlasterConfig {
 	public int MissileBlastRadius;
 	public int RoundsBetweenMissiles;
 	public int RoundsBeforeIncreasingBlastRadius;
+	public int BombRoundsUntilExplodes;
 }

--- a/dotNet/TankBlaster/TankBlasterBot/SampleWebBotClient/Models/TankBlaster/TankBlasterConfig.cs
+++ b/dotNet/TankBlaster/TankBlasterBot/SampleWebBotClient/Models/TankBlaster/TankBlasterConfig.cs
@@ -8,5 +8,6 @@
         public int MissileBlastRadius { get; set; }
         public int RoundsBetweenMissiles { get; set; }
         public int RoundsBeforeIncreasingBlastRadius { get; set; }
+        public int BombRoundsUntilExplodes { get; set; }
     }
 }


### PR DESCRIPTION
Replacing a magic constant for the number of rounds required for bomb to explode with new value in game config. The value is also passed to each player in game config structure.